### PR TITLE
Add the allow field to all the locations

### DIFF
--- a/templates/cupsd.conf.j2
+++ b/templates/cupsd.conf.j2
@@ -38,6 +38,9 @@ WebInterface {{ cups_web_interface }}
 {% if location.require is defined %}
   require {{ location.require }}
 {% endif %}
+{% if location.allow is defined %}
+  Allow {{ location.allow }}
+{% endif %}
 </Location>
 
 {% endfor %}


### PR DESCRIPTION
The template did not include the allow field to be inserted into the configuration, therefore not allowing remote users to access the CUPS web interface.

Fixes Issue #1 