### PR TITLE
Added simple variable defs for policy defaults and adjusted template to include them.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,20 @@ cups_preserve_job_history: true
 
 # Cups can offer a web-interface. (boolean)
 cups_web_interface: true
+
+# Default policy settings for Cups
+# JobPrivateAccess (string) should be one of "default", "all", or an ACL string
+# consisting of a space separated list of one or more of:
+# user, @group, @ACL, @OWNER, and @SYSTEM. The default is "@OWNER @SYSTEM"
+cups_job_private_access: "default"
+# Specifies the list of job values to make private. The "default" values are:
+# "job-name", "job-originating-host-name", "job-originating-user-name", and "phone".
+# You can also set it to "none" or "all"
+cups_job_private_values: "default"
+# As per JobPrivateAccess, but for subscription events
+cups_sub_private_access: "default"
+# Specifies the list of subscription values to make private. The "default" values are:
+# "notify-events", "notify-pull-method", "notify-recipient-uri", 
+# "notify-subscriber-user-name", and "notify-user-data".
+# You can also set it to "none" or "all"
+cups_sub_private_values: "default"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ cups_listen: "localhost:631"
 cups_serveralias: "*"
 
 # Share local printers on the local network. (boolean)
-cups_browsing: no
+cups_browsing: false
 
 # Allow access to the server...
 cups_locations:
@@ -27,7 +27,7 @@ cups_locations:
     order: allow,deny
 
 # Cups can save a job history. (boolean)
-cups_preserve_job_history: yes
+cups_preserve_job_history: true
 
 # Cups can offer a web-interface. (boolean)
-cups_web_interface: yes
+cups_web_interface: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,9 +9,9 @@
 - name: Reload disabled AppArmor cups profile
   ansible.builtin.command:
     cmd: apparmor_parser -R /etc/apparmor.d/disable/usr.sbin.cupsd
-  changed_when: yes
+  changed_when: true
 
 - name: Load the AppArmor cups profile
   ansible.builtin.shell:
     cmd: "apparmor_parser -a < /etc/apparmor.d/usr.sbin.cupsd"
-  changed_when: yes
+  changed_when: true

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -6,21 +6,21 @@
       - cups_listen is defined
       - cups_listen is string
       - cups_listen is not none
-    quiet: yes
+    quiet: true
 
 - name: assert | Test cups_browsing
   ansible.builtin.assert:
     that:
       - cups_browsing is defined
       - cups_browsing is boolean
-    quiet: yes
+    quiet: true
 
 - name: assert | Test cups_locations
   ansible.builtin.assert:
     that:
       - cups_locations is defined
       - cups_locations is iterable
-    quiet: yes
+    quiet: true
 
 - name: assert | Test item in cups_locations
   ansible.builtin.assert:
@@ -31,7 +31,7 @@
       - item.order is defined
       - item.order is string
       - item.order is not none
-    quiet: yes
+    quiet: true
   loop: "{{ cups_locations }}"
   loop_control:
     label: "{{ item.name }}"
@@ -40,7 +40,7 @@
   ansible.builtin.assert:
     that:
       - item.authtype in [ "Basic", "Default", "Negotiate", "None" ]
-    quiet: yes
+    quiet: true
   loop: "{{ cups_locations }}"
   loop_control:
     label: "{{ item.name }}"
@@ -52,7 +52,7 @@
     that:
       - item.allow is string
       - item.allow is not none
-    quiet: yes
+    quiet: true
   loop: "{{ cups_locations }}"
   loop_control:
     label: "{{ item.name }}"
@@ -64,11 +64,11 @@
     that:
       - cups_preserve_job_history is defined
       - cups_preserve_job_history is boolean
-    quiet: yes
+    quiet: true
 
 - name: assert | Test cups_web_interface
   ansible.builtin.assert:
     that:
       - cups_web_interface is defined
       - cups_web_interface is boolean
-    quiet: yes
+    quiet: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Import assert.yml
   ansible.builtin.import_tasks:
     file: assert.yml
-  run_once: yes
+  run_once: true
   delegate_to: localhost
 
 - name: Install packages
@@ -65,4 +65,4 @@
   ansible.builtin.service:
     name: "{{ cups_service }}"
     state: started
-    enabled: yes
+    enabled: true

--- a/templates/cupsd.conf.j2
+++ b/templates/cupsd.conf.j2
@@ -49,10 +49,10 @@ WebInterface {{ cups_web_interface | ternary('Yes', 'No') }}
 # Set the default printer/job policies...
 <Policy default>
   # Job/subscription privacy...
-  JobPrivateAccess default
-  JobPrivateValues default
-  SubscriptionPrivateAccess default
-  SubscriptionPrivateValues default
+  JobPrivateAccess  {{ cups_job_private_access }}
+  JobPrivateValues {{ cups_job_private_values }}
+  SubscriptionPrivateAccess {{ cups_sub_private_access }}
+  SubscriptionPrivateValues {{ cups_sub_private_values }}
 
   # Job-related operations must be done by the owner or an administrator...
   <Limit Create-Job Print-Job Print-URI Validate-Job>


### PR DESCRIPTION
I had a client who needed slightly more granular policy definition around who could see what.
I've implemented just the bare minimum of what they required. It would be good to extend this to generic policy at a later date.
I've ensured that if left alone, cupsd.conf will be exactly as it was before this PR.